### PR TITLE
docs: update oracles-tvs.md with new oraclesBreakdown format

### DIFF
--- a/list-your-project/oracles-tvs.md
+++ b/list-your-project/oracles-tvs.md
@@ -82,7 +82,6 @@ oraclesBreakdown: [
 * `proof`: At least one link (docs, code, or audit) showing the oracle integration.
 
 **Optional fields:**
-**Optional fields:**
 * `startDate` / `endDate`: Use these to indicate the active period (format: YYYY-MM-DD).  
   If `startDate` is not provided, we assume the oracle has been active since the protocol's launch.
 * `chains`: List of chain slugs from [`normalizeChain.ts`](https://github.com/DefiLlama/defillama-server/blob/master/defi/src/utils/normalizeChain.ts), with optional start/end dates per chain.  


### PR DESCRIPTION
## Summary
This PR updates the oracle docs to reflect current standards, replacing deprecated (oracles and oraclesByChain) fields and clarifies how to use `oraclesBreakdown`.

## What's Changed

- Removed references to `oracles` and `oraclesByChain`
- Documented `oraclesBreakdown` structure with detailed examples
- Added definitions for all oracle types (Primary, Secondary, Fallback, Aggregator, RNG)
- Clarified required vs. optional fields, including `chains` and date support
- Linked relevant files (`normalizeChain.ts`, DefiLlama server repo)
- Adds mention of `data3.ts` and `data4.ts` files for protocol entries